### PR TITLE
Remove funcionalidade do botão de usuário no menu e permite colocar usuário no nível avaliador.

### DIFF
--- a/frontend/src/app/components/menubar/menuBar.module.css
+++ b/frontend/src/app/components/menubar/menuBar.module.css
@@ -28,7 +28,6 @@
   gap: 8px;
   font-size: 1rem;
   color: #444;
-  cursor: pointer;
 }
 
 .userName {

--- a/frontend/src/app/components/menubar/menubar.js
+++ b/frontend/src/app/components/menubar/menubar.js
@@ -22,21 +22,6 @@ export default function MenuBar({ hasNotification }) {
     }
   }, []);
 
-  const handleUserClick = () => {
-    if (userId) {
-      // Navegar para a página de usuários com parâmetro para editar o próprio usuário
-      router.push(`/usuarios?editSelf=true`);
-    } else {
-      // Se não tiver ID, tentar buscar
-      const user = authService.getUser();
-      if (user && user.id) {
-        router.push(`/usuarios?editSelf=true`);
-      } else {
-        showNotification("Erro ao carregar dados do usuário", "error");
-      }
-    }
-  };
-
   const handleLogout = () => {
     authService.logout();
     showNotification("Logout realizado com sucesso!", "success");
@@ -46,7 +31,7 @@ export default function MenuBar({ hasNotification }) {
   return (
     <header className={styles.menuBar}>
       <div className={styles.rightSection}>
-        <div className={styles.userInfo} onClick={handleUserClick}>
+        <div className={styles.userInfo}>
           <UserIcon />
           <span className={styles.userName}>{userName}</span>
           <span className={styles.arrowDown}>▼</span>

--- a/frontend/src/app/usuarios/page.js
+++ b/frontend/src/app/usuarios/page.js
@@ -110,6 +110,9 @@ export default function UsuariosPage() {
     if (nameLower.includes('attendant') || nameLower.includes('atendente')) {
       return 'Atendente';
     }
+    if (nameLower.includes('evaluator') || nameLower.includes('avaliador')) {
+      return 'Avaliador';
+    }
     return name; // Retorna o nome original se não for reconhecido
   };
 
@@ -120,7 +123,8 @@ export default function UsuariosPage() {
       const filteredProfiles = (data || []).filter(profile => {
         const nameLower = (profile.name || '').toLowerCase();
         return nameLower.includes('admin') || nameLower.includes('administrator') || 
-               nameLower.includes('attendant') || nameLower.includes('atendente');
+               nameLower.includes('attendant') || nameLower.includes('atendente') ||
+               nameLower.includes('evaluator') || nameLower.includes('avaliador');
       });
       setProfiles(filteredProfiles);
     } catch (err) {

--- a/frontend/src/app/usuarios/page.js
+++ b/frontend/src/app/usuarios/page.js
@@ -40,59 +40,16 @@ export default function UsuariosPage() {
   const [formErrors, setFormErrors] = useState({});
   const [editFormErrors, setEditFormErrors] = useState({});
   const [changePassword, setChangePassword] = useState(false);
-  const [allowNonAdminEdit, setAllowNonAdminEdit] = useState(false);
 
   useEffect(() => {
-    // Verificar se deve permitir edição de não-admin (editando a si mesmo)
-    const urlParams = new URLSearchParams(window.location.search);
-    if (urlParams.get('editSelf') === 'true') {
-      setAllowNonAdminEdit(true);
-    }
-    
     const initialize = async () => {
       await checkAdmin();
       await loadUsers();
       await loadProfiles();
-      
-      // Verificar se deve abrir o modal de edição do próprio usuário
-      if (urlParams.get('editSelf') === 'true') {
-        handleEditSelf();
-        // Limpar o parâmetro da URL
-        window.history.replaceState({}, '', '/usuarios');
-      }
     };
     
     initialize();
   }, []);
-
-  const handleEditSelf = async () => {
-    try {
-      const user = authService.getUser();
-      if (!user || !user.id) {
-        showNotification("Erro ao carregar dados do usuário", "error");
-        return;
-      }
-      
-      // Carregar dados do usuário atual
-      const userData = await apiService.getUser(user.id);
-      const mappedUser = mapUserFromBackend(userData);
-      setEditFormData({
-        nomeCompleto: mappedUser.nomeCompleto || '',
-        email: mappedUser.email || '',
-        login: mappedUser.login || '',
-        senha: '',
-        perfilId: mappedUser.perfilId?.toString() || '',
-        status: mappedUser.status || 'ACTIVE'
-      });
-      setEditFormErrors({});
-      setChangePassword(false);
-      setEditingUser(mappedUser);
-      setShowEditModal(true);
-    } catch (err) {
-      console.error("Erro ao carregar usuário:", err);
-      showNotification(err.message || "Erro ao carregar dados do usuário", "error");
-    }
-  };
 
   const checkAdmin = async () => {
     const user = authService.getUser();
@@ -316,14 +273,6 @@ export default function UsuariosPage() {
 
   const handleEditSubmit = async (e) => {
     e.preventDefault();
-    // Verificar se está editando a si mesmo ou se é admin
-    const currentUser = authService.getUser();
-    const isEditingSelf = currentUser && editingUser && currentUser.id === editingUser.id;
-    
-    if (!isAdmin && !isEditingSelf) {
-      showNotification("Apenas administradores podem editar outros usuários", "error");
-      return;
-    }
 
     const errors = validateEditForm();
     if (Object.keys(errors).length > 0) {
@@ -369,7 +318,7 @@ export default function UsuariosPage() {
     }
   };
 
-  if (!isAdmin && !allowNonAdminEdit) {
+  if (!isAdmin) {
     return (
       <div className={styles.containerGeral}>
         <Navigation />


### PR DESCRIPTION
O botão de perfil no menu superior não redireciona o usuário para a tela de usuários e não abre a página de edição de usuário.

Remove parte do código que verifica se usuário é ou não administrador na tela de usuários, visto que a lógica do programa não permite que um usuário não administrador não pode acessar a janela.

Ao editar ou adicionar um usuário, é possível escolher "Avaliador" ("evaluator" / 3) como nível de permissão do usuário.